### PR TITLE
Articleモデル関連のアップデート

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -88,11 +88,31 @@
 }
 
 .article-sidebar {
-  text-align: center;
   border-left: 1px rgb(110, 110, 110) solid;
+
   h5 {
     text-decoration: underline;
   }
+
+  .related-article-wrapper {
+
+    padding: 5px 0;
+
+    .article-sidebar-image {
+      width: 70%;
+      height: auto;
+      margin: 0 auto;
+      display: block;
+      border-radius: 5px;
+    }
+  
+    p {
+      width: 70%;
+      height: auto;
+      margin: 0 auto;
+    }
+
+  }  
 }
 
 .bookmark-wrapper {

--- a/app/assets/stylesheets/static_pages.scss
+++ b/app/assets/stylesheets/static_pages.scss
@@ -43,6 +43,28 @@
   font-size: 0.8rem;
 }
 
+.article-top-wrapper {
+  margin: 15px 0;
+}
+
+.article-top-image {
+  display:block;
+  margin: 0 auto;
+  border-radius: 5px;
+}
+
+.article-top-info {
+  padding:15px 0;
+  border-bottom: 1px rgb(158, 157, 157) solid;
+}
+
+/* 992px以下の場合 */
+@media screen and (max-width: 992px) {
+  .article-top-image {
+    width: 100%;
+    height: auto;
+  }
+}
 
 
 /* 768px以下の場合 */
@@ -51,6 +73,20 @@
     padding:0 20px;
   }
 }
+
+/* 576px以下の場合 */
+@media screen and (max-width: 576px) {
+  .article-top-image {
+    width: 80%;
+    height: auto;
+  }
+
+  .article-top-info {
+    width: 80%;
+    margin: 0 auto;
+  }
+}
+
 
  /* 480px以下の場合 */
 @media screen and (max-width: 481px) {

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -19,6 +19,12 @@ class ArticlesController < ApplicationController
 
   def show
     @article = Article.find_by(id: params[:id])
+
+    if @article.category_id.nil?
+      @related_articles = Article.where(category_id: nil).where.not(id: @article.id).select(:id, :title, :category_id).order(Arel.sql("RAND()")).limit(5)
+    else
+      @related_articles = Article.where(category_id: @article.category_id).where.not(id: @article.id).select(:id, :title, :category_id).order(Arel.sql("RAND()")).limit(5)
+    end
   end
 
   def create
@@ -35,7 +41,6 @@ class ArticlesController < ApplicationController
   
   def edit
     @article = current_user.articles.find_by(id: params[:id])
-    
   end
 
   def update

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -5,7 +5,7 @@ class StaticPagesController < ApplicationController
       @user = current_user
       @feed_items = current_user.feed.page(params[:page]).per(15)
     else
-      @top_articles = Article.find(Bookmark.group(:article_id).order('count(article_id) desc').limit(6).pluck(:article_id))
+      @top_articles = Article.find(Bookmark.group(:article_id).order(Arel.sql('count(article_id) desc')).limit(6).pluck(:article_id))
     end
   end
   

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -44,7 +44,6 @@
       <% article.tags.pluck(:name).each do |tag_name| %>
         <span class="badge badge-info"><%= link_to tag_name, tag_path(tag_name), class: "article-tag" %></span>
       <% end %>
-      </span>
     </div>
     
     <div class="article-information">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -32,6 +32,18 @@
 
     <div class="col-lg-3 article-sidebar">
       <h5>関連した記事</h5>
+        <% @related_articles.each do |article| %>
+          <div class="related-article-wrapper">
+            <% if article.thumbnail.url %>
+              <%= image_tag article.thumbnail.url, class: "article-sidebar-image", size: "300x300"  %>
+            <% elsif article.category %>
+              <%= image_tag "categories/category_#{article.category.name}.jpg", class: "article-sidebar-image", size: "300x300" %>
+            <% else %>
+              <%= image_tag 'default_thumbnail.png', class: "article-sidebar-image", size: "300x300" %>
+            <% end %>
+            <p><%=link_to article.title, article_path(article), class: "h6 d-block"  %></p>
+          </div>
+        <% end %>
     </div>
   </div>
 </div> 

--- a/app/views/shared/_unloggedin_home.html.erb
+++ b/app/views/shared/_unloggedin_home.html.erb
@@ -12,24 +12,23 @@
 
     <div class="row">
       <% @top_articles.each do |article| %>
-        <div class="col-12 col-sm-6 col-lg-4">
+        <div class="article-top-wrapper col-12 col-sm-6 col-lg-4">
            <% if article.thumbnail.url %>
-            <%= image_tag article.thumbnail.url, class: "article-image", size: "300x300", id: "attached-picture" %>
+            <%= image_tag article.thumbnail.url, class: "article-top-image", size: "300x300", id: "attached-picture" %>
           <% elsif article.category %>
-            <%= image_tag "categories/category_#{article.category.name}.jpg", class: "article-image", size: "300x300", id: "category-picture" %>
+            <%= image_tag "categories/category_#{article.category.name}.jpg", class: "article-top-image", size: "300x300", id: "category-picture" %>
           <% else %>
-            <%= image_tag 'default_thumbnail.png', class: "article-image", size: "300x300", id: "default-picture" %>
+            <%= image_tag 'default_thumbnail.png', class: "article-top-image", size: "300x300", id: "default-picture" %>
           <% end %>
-          <h3><%= article.title %></h3>
 
-          <div> 
+          <div class="article-top-info"> 
+            <%= link_to article.title, article_path(article), class: "h3 d-block" %>
             <span class="article-category badge badge-warning">
               カテゴリ：<%= (article.category.nil?) ? "なし" : article.category.name %>
             </span>
             <% article.tags.pluck(:name).each do |tag_name| %>
               <span class="badge badge-info"><%= link_to tag_name, tag_path(tag_name), class: "article-tag" %></span>
             <% end %>
-            </span>
           </div>
       
         </div>

--- a/spec/system/articles_crud_spec.rb
+++ b/spec/system/articles_crud_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Articles', type: :system do
+RSpec.describe 'ArticlesCRUD', type: :system do
   
   let(:user) { FactoryBot.create(:user) }
   let(:other_user) { FactoryBot.create(:other_user) }
@@ -116,22 +116,4 @@ RSpec.describe 'Articles', type: :system do
     end    
   end
 
-  describe "article show page" do
-    it "displays title and content" do
-      sign_in_as user
-      post_new_article
-
-      click_on "Test title"
-      expect(page).to have_content "Test title"
-      expect(page).to have_content "Test content"
-    end
-
-    it "allows for user to check other user's article" do
-    end
-
-    it "allows for unloggedin user to check user's article" do
-    end
-  end
-
-  
 end

--- a/spec/system/articles_show_spec.rb
+++ b/spec/system/articles_show_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'ArticlesShow', type: :system do
+  
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "article show page" do
+
+    it "displays title and content" do
+      sign_in_as user
+      post_new_article
+  
+      click_on "Test title"
+      expect(page).to have_content "Test title"
+      expect(page).to have_content "Test content"
+    end
+  
+    it "displays related articles" do
+      Category.create(id:1, name: "天文学")
+      Category.create(id:2, name: "遺伝学")
+      article = Article.create(title: "Test title", content: "Test content", user_id: user.id, category_id: 1)
+      articles_in_same_category = FactoryBot.create_list(:articles, 4, user: user, category_id:1)
+      articles_in_different_category = FactoryBot.create_list(:articles, 4, user: user, category_id:2)
+
+      visit article_path(article)
+      
+      articles_in_same_category.each do |article|
+        expect(page).to have_content article.title
+      end
+
+      articles_in_different_category.each do |article|
+        expect(page).to_not have_content article.title
+      end
+
+      expect(find('.article-sidebar')).to_not have_text article.title
+    end
+  end
+  
+end
+

--- a/spec/system/categories_spec.rb
+++ b/spec/system/categories_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Categories', type: :system do
   let(:user) { FactoryBot.create(:user) }
   let(:article) { FactoryBot.create(:article, user: user) }
   
-  before :all do
+  before do
     categories = %w[遺伝学 天文学 医学 水産学 動物学]
     categories.each {|category| Category.create(name: category)}
   end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'StaticPages', type: :system do
+
+  describe "top page" do
+
+    it "shows most bookmarked articles" do
+      user = FactoryBot.create(:user)
+      users = FactoryBot.create_list(:users, 20)
+      articles = FactoryBot.create_list(:articles, 20, user: user)
+
+      users.each do |user|
+        articles.last(6).each do |article|
+          Bookmark.create(user_id: user.id, article_id: article.id)
+        end
+      end
+
+      visit root_path
+
+      articles.last(6).each do |article|
+        expect(page).to have_content "#{article.title}"
+      end
+
+      articles.first(14).each do |article|
+        expect(page).to_not have_content "#{article.title}"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
・非ログイン時のトップページに、人気の記事（いいね の多い記事トップ6まで）を表示
・記事の詳細画面にて、関連した記事（同じカテゴリーidを持つ記事）を5つまで表示
・システムスペック のみテスト