### PR TITLE
Nginxのkeepalive_timeoutを変更

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -31,6 +31,6 @@ server {
   error_page 404             /404.html;
   error_page 505 502 503 504 /500.html;
   try_files  $uri/index.html $uri @app;
-  keepalive_timeout 5;
+  keepalive_timeout 180;
 }       
 


### PR DESCRIPTION
・ALBのヘルスチェックで504が帰ってきたため、Nginxのkeepalive_timeoutを5秒から180へ変更